### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 For content, see the `*.md` files by game:
 
-- [D&D 5th Edition](DND-5E.md)
+- [D&D 5th Edition](dnd-5e/)


### PR DESCRIPTION
Update the link to point to the D&D 5e folder, rather than a non-existant file